### PR TITLE
Fix typos, make punctuation consistent.

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,13 +4,13 @@ layout: default
 
 ## You are cordially invited to write an article for the 2016 Perl Advent Calendar.
 
-As an advent calendar author you will write on entry on a module of your
+As an advent calendar author you will write one entry on a module of your
 choosing that will be revealed to the world on
 [The Perl Advent Calendar](http://www.perladvent.org/)
-on a given day of advent (between the 1st and 24th of December 2016 inclusive.)
+on a given day of Advent (between the 1st and 24th of December 2016 inclusive).
 
-The Perl Advent Calendar welcome diverse author submissions from all types of
-Perl programmer.  It is our firm belief that every Perl Programmer, no matter
+The Perl Advent Calendar welcomes diverse author submissions from all types of
+Perl programmer.  It is our firm belief that every Perl programmer, no matter
 how advanced or how novice, has a favorite Perl module they want to tell the
 world about.  The module that is the subject of the article need not be written
 by the article author, and more often than not this is not the case.
@@ -18,7 +18,7 @@ by the article author, and more often than not this is not the case.
 The Perl Advent Calendar also believes that the pool of authors should not be
 limited to people who have English as their first language.  Authors who speak
 English as a second language are encouraged to submit.  Each article submission
-undergoes an editorial process which assist those authors who may need help
+undergoes an editorial process which assists those authors who may need help
 with their writing.
 
 In order to participate in the Perl Advent Calendar please use
@@ -32,20 +32,20 @@ We look forward to hearing from you!
 ### Timelines ###
 
 * 11:59 PM EST Saturday **October 15th 2016**:
-  Deadline for Call For Participation.
+  Deadline for Call For Participation (CFP).
 
 * 11:59 PM EST Sunday **October 16th 2016**: Authors of all CFP submissions will
-  be notified if their article has been accepted
+  be notified if their article has been accepted.
 
 * 11:59 PM EST Tuesday **November 1st 2016**: First draft of article submission
   committed by author into Perl Advent Calendar Github repository.  This need
   not be 100% completed at this point, but at this point the Perl Advent
   Calendar editorial team will start the editing process (correcting typos,
   editing for house style, making sure the article renders correctly, suggesting
-  language and graphics improvements, etc.)
+  language and graphics improvements, etc).
 
 * 11:59 PM EST Wednesday **November 30th 2016**: Deadline for the final changes
-  to the articles
+  to the articles.
 
 * 12:00 AM EST Thursday **December 1st 2016**: Advent begins.  Go live date.
 
@@ -60,7 +60,7 @@ try to be entertaining in our articles.
 
 - We like our articles to contain text and code interspersed, and if necessary a final script at the end with lots of comments.
 
-- Pictures, graphs, and other graphics are good and highly encouraged.  Last year we included animated gifs of terminal output, renderes of spinning OpenGL snowflakes, and a full interactive JavaScript map of the world showing off GeoIP location from Perl.
+- Pictures, graphs, and other graphics are good and highly encouraged.  Last year we included animated gifs of terminal output, renders of spinning OpenGL snowflakes, and a full interactive JavaScript map of the world showing off GeoIP location from Perl.
 
 - Formatting is in POD with a custom header.  See [the source for previous year's articles](https://github.com/perladvent/Perl-Advent/tree/master/2015/articles) for examples.  You can use [`=for html`](https://github.com/perladvent/Perl-Advent/blame/master/2015/articles/2015-12-02.pod#L75) or even [`=for web_only` and `=for rss_only`](https://github.com/perladvent/Perl-Advent/blame/master/2015/articles/2015-12-01.pod#L7) if needed to add custom HTML to your POD.
 


### PR DESCRIPTION
Also explain the CFP abbreviation (I know it should be obvious, but people do sometimes find this sort of thing confusing).
