### PR TITLE
Update to 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'jekyll'
+gem 'kramdown-parser-gfm'

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
-title: Perl Advent Calendar 2019 CFP
-tag_text: Perl Advent Calendar 2019 CFP
-description: The Call For Partipation for the 2018 Perl Advent Calendar
+title: Perl Advent Calendar 2022 CFP
+tag_text: Perl Advent Calendar 2022 CFP
+description: The Call For Participation for the 2022 Perl Advent Calendar
 url: "http://127.0.0.1:4000"
 baseurl: ""
 

--- a/_includes/sharing.html
+++ b/_includes/sharing.html
@@ -2,7 +2,7 @@
   <ul class="rrssb-buttons rrssb-1">
     <li class="rrssb-email">
       <!-- Replace subject with your message using URL Endocding: http://meyerweb.com/eric/tools/dencoder/ -->
-      <a href="mailto:?subject=The%202016%20Perl%20Adevent%20Calendar%20CFP%20is%20open%20http%3A%2F%2Fcfp.perladvent.org%2F">
+      <a href="mailto:?subject=The%202022%20Perl%20Advent%20Calendar%20CFP%20is%20open%20http%3A%2F%2Fcfp.perladvent.org%2F">
         <span class="rrssb-icon"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><path d="M20.11 26.147c-2.335 1.05-4.36 1.4-7.124 1.4C6.524 27.548.84 22.916.84 15.284.84 7.343 6.602.45 15.4.45c6.854 0 11.8 4.7 11.8 11.252 0 5.684-3.193 9.265-7.398 9.3-1.83 0-3.153-.934-3.347-2.997h-.077c-1.208 1.986-2.96 2.997-5.023 2.997-2.532 0-4.36-1.868-4.36-5.062 0-4.75 3.503-9.07 9.11-9.07 1.713 0 3.7.4 4.6.972l-1.17 7.203c-.387 2.298-.115 3.3 1 3.4 1.674 0 3.774-2.102 3.774-6.58 0-5.06-3.27-8.994-9.304-8.994C9.05 2.87 3.83 7.545 3.83 14.97c0 6.5 4.2 10.2 10 10.202 1.987 0 4.09-.43 5.647-1.245l.634 2.22zM16.647 10.1c-.31-.078-.7-.155-1.207-.155-2.572 0-4.596 2.53-4.596 5.53 0 1.5.7 2.4 1.9 2.4 1.44 0 2.96-1.83 3.31-4.088l.592-3.72z"/></svg></span>
         <span class="rrssb-text">email</span>
       </a>
@@ -19,7 +19,7 @@
 
     <li class="rrssb-twitter">
       <!-- Replace href with your Meta and URL information  -->
-      <a href="https://twitter.com/intent/tweet?text=The+2016+Perl+Advent+Calendar+CFP+is+open+http://cfp.perladvent.org/"
+      <a href="https://twitter.com/intent/tweet?text=The+2022+Perl+Advent+Calendar+CFP+is+open+http://cfp.perladvent.org/"
       class="popup">
         <span class="rrssb-icon">
           <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
@@ -36,13 +36,6 @@
       <a href="http://www.linkedin.com/shareArticle?mini=true&amp;url=http://cfp.perladvent.org" class="popup">
         <span class="rrssb-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28"><path d="M25.424 15.887v8.447h-4.896v-7.882c0-1.98-.71-3.33-2.48-3.33-1.354 0-2.158.91-2.514 1.802-.13.315-.162.753-.162 1.194v8.216h-4.9s.067-13.35 0-14.73h4.9v2.087c-.01.017-.023.033-.033.05h.032v-.05c.65-1.002 1.812-2.435 4.414-2.435 3.222 0 5.638 2.106 5.638 6.632zM5.348 2.5c-1.676 0-2.772 1.093-2.772 2.54 0 1.42 1.066 2.538 2.717 2.546h.032c1.71 0 2.77-1.132 2.77-2.546C8.056 3.593 7.02 2.5 5.344 2.5h.005zm-2.48 21.834h4.896V9.604H2.867v14.73z"/></svg></span>
         <span class="rrssb-text">linkedin</span>
-      </a>
-    </li>
-    <li class="rrssb-googleplus">
-      <a href="https://plus.google.com/share?url=http://cfp.perladvent.org" class="popup">
-        <span class="rrssb-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M21 8.29h-1.95v2.6h-2.6v1.82h2.6v2.6H21v-2.6h2.6v-1.885H21V8.29zM7.614 10.306v2.925h3.9c-.26 1.69-1.755 2.925-3.9 2.925-2.34 0-4.29-2.016-4.29-4.354s1.885-4.353 4.29-4.353c1.104 0 2.014.326 2.794 1.105l2.08-2.08c-1.3-1.17-2.924-1.883-4.874-1.883C3.65 4.586.4 7.835.4 11.8s3.25 7.212 7.214 7.212c4.224 0 6.953-2.988 6.953-7.082 0-.52-.065-1.104-.13-1.624H7.614z"/></svg>            </span>
-        <span class="rrssb-text">google+</span>
       </a>
     </li>
   </ul>

--- a/accepted.md
+++ b/accepted.md
@@ -19,14 +19,14 @@ And clone the repository.
     git clone git@github.com:perladvent/Perl-Advent.git
 
 Once you've got a local clone of the repo you should go ahead and *switch to the
-y2016 branch*.
+y2022 branch*.
 
     cd Perl-Advent
-    git checkout y2016
+    git checkout y2022
 
 Then you should enter the submission directory:
 
-    cd 2016/submission
+    cd 2022/submission
 
 Now you should create your article in this directory.  Call it something
 named after the module
@@ -39,7 +39,7 @@ named after the module
 You'll note that you're *directly* working in the live repo here - there's no
 need for pull requests when editing your own submission. (However: if you want
 to make other changes to other articles etc, you should however make a new
-branch from y2016 then make a pull request against y2016.)
+branch from y2022 then make a pull request against y2022.)
 
 ## Local previewing
 
@@ -51,27 +51,27 @@ module from the CPAN:
      cpanm WWW::AdventCalendar
 
 Then you'll be able to build the advent calendar.  First change to the top
-level entry for y2016:
+level entry for y2022:
 
     cd Perl-Advent
-    cd 2016
+    cd 2022
 
 Copy over the submission
 
     mkdir articles
-    cp submission/my-module-name-in-kebab-case.pod articles/2016-12-01.pod
+    cp submission/my-module-name-in-kebab-case.pod articles/2022-12-01.pod
 
 Then run the `advcal` command
 
-    advcal -c advent.ini --today 2017-01-01
+    advcal -c advent.ini --today 2022-01-01
 
-You can now see the resulting article in `out/2016-12-01.html`!
+You can now see the resulting article in `out/2022-12-01.html`!
 
 Whatever you do, don't check in the articles directory with these changes!
 Heck, you might want to protect yourself from accidentally doing that:
 
     cd ..
-    echo '2016/articles' >>.git/info/exclude
+    echo '2022/articles' >>.git/info/exclude
 
 (You can undo this later when your article has been officially moved to this
 directory)
@@ -79,7 +79,7 @@ directory)
 ### Guidelines on the Articles ###
 
 - The best way to see what we're after in an article is to take a look at
-  [the previous year's articles](http://www.perladvent.org/2015/).
+  [the previous years' articles](http://www.perladvent.org/2015/).
 
 - Our articles should try and be light and trivial and along the Christmas theme.  Our variable names can be `$rudolph`, or `$frosty`, or `$mrhankey`.  Our articles
 are often stories of problems fictional Christmas characters have.  In all, we
@@ -95,7 +95,7 @@ try to be entertaining in our articles.
 
 As time moves on the editors will move your article from the submissions
 directory into the articles directory.  At that point your article will get a
-`2016-12-DD.pod` file name which will determine when it goes live.
+`2022-12-DD.pod` file name which will determine when it goes live.
 
 However: Note that the exact date that things go live are always subject to
 last minute changes (or how we like to say in the business "Oh crud that other
@@ -108,17 +108,17 @@ article goes live will automatically be published within the hour.
 
 As a reminder, here's the deadlines for the article:
 
-* 11:59 PM EST Tuesday **November 1st 2016**: First draft of article submission
+* 11:59 PM EST Tuesday **November 1st 2022**: First draft of article submission
   committed by author into Perl Advent Calendar Github repository.  This need
   not be 100% completed at this point, but at this point the Perl Advent
   Calendar editorial team will start the editing process (correcting typos,
   editing for house style, making sure the article renders correctly, suggesting
   language and graphics improvements, etc.)
 
-* 11:59 PM EST Wednesday **November 30th 2016**: Deadline for the final changes
+* 11:59 PM EST Tuesday **November 15th 2022**: Deadline for the final changes
   to the articles
 
-* 12:00 AM EST Thursday **December 1st 2016**: Advent begins.  Go live date.
+* 12:00 AM EST Thursday **December 1st 2022**: Advent begins.  Go live date.
 
 ## Questions?
 

--- a/index.md
+++ b/index.md
@@ -2,24 +2,24 @@
 layout: default
 ---
 
-## You are cordially invited to write an article for the 2019 Perl Advent Calendar.
+## You are cordially invited to write an article for the 2022 Perl Advent Calendar.
 
-The CFP is open until midnight on Monday September 30th EST.
+The CFP is open until midnight on Friday September 30th EST.
 
 ## What's all this about then?
 
 As an advent calendar author you will write one entry on a module of your
 choosing that will be revealed to the world on
 [The Perl Advent Calendar](http://www.perladvent.org/)
-on a given day of Advent (between the 1st and 24th of December 2019 inclusive).
+on a given day of Advent (between the 1st and 24th of December 2022 inclusive).
 
 The Perl Advent Calendar welcomes diverse author submissions from all types of
-Perl programmer.  It is our firm belief that every Perl programmer, no matter
+Perl programmers.  It is our firm belief that every Perl programmer, no matter
 how advanced or how novice, has a favorite Perl module they want to tell the
 world about.  The module that is the subject of the article need not be written
 by the article author, and more often than not this is not the case.
 
-The Perl Advent Calendar seeks to be an inclusive projects.
+The Perl Advent Calendar seeks to be an inclusive project.
 We encourage and sincerely welcome articles from authors of color,
 women, queer article authors, transgender authors and from other communities
 not well represented in the tech world.  We do not discrimnate on the basis
@@ -37,8 +37,8 @@ with their writing.
 In order to participate in the Perl Advent Calendar please use
 [this form](https://docs.google.com/forms/d/e/1FAIpQLSfQUctVOLGhwCZtBKlnPaGxcszmQiBsq5Wck-t5ceGpB6C1IQ/viewform)
 to submit your chosen module and a brief description of your article (which need
-be no more than two or three sentences) by no later than **11:59 PM EST Monday
-September 30th 2019**.  If you don't have an idea for an article but would
+be no more than two or three sentences) by no later than **11:59 PM EST Friday
+September 30th 2022**.  If you don't have an idea for an article but would
 be open to some suggestions or coming up with an article idea later on, just say
 so in the submission!
 
@@ -46,36 +46,37 @@ We look forward to hearing from you!
 
 ### Timelines ###
 
-* 11:59 PM EST Monday September 30th 2019: Deadline for article proposal
+* 11:59 PM EST Friday September 30th 2022: Deadline for article proposal
   submission.
 
-* 11:59 PM EST Tuesday **October 1st 2019**: Authors of all CFP submissions will
+* 11:59 PM EST Saturday **October 1st 2022**: Authors of all CFP submissions will
   be notified if their article has been accepted.
 
-* 11:59 PM EST Friday **November 1st 2019**: First draft of article submission
+* 11:59 PM EST Tuesday **November 1st 2022**: First draft of article submission
   committed by author into Perl Advent Calendar Github repository.  This need
-  not be 100% completed at this point, but at this point the Perl Advent
+  not be 100% completed at this point, but at this stage the Perl Advent
   Calendar editorial team will start the editing process (correcting typos,
   editing for house style, making sure the article renders correctly, suggesting
   language and graphics improvements, etc).
 
-* 11:59 PM EST Friday **November 15th 2019**: Deadline for the final changes
+* 11:59 PM EST Tuesday **November 15th 2022**: Deadline for the final changes
   to the articles.
 
-* 12:00 AM EST Sunday **December 1st 2019**: Advent begins.  Go live date.
+* 12:00 AM EST Thursday **December 1st 2022**: Advent begins.  Go live date.
 
 ### Guidelines on the Articles ###
 
 - The best way to see what we're after in an article is to take a look at
   [a previous year's articles](http://www.perladvent.org/2017/).
 
-- Our articles should try and be light and trivial and along the Christmas theme.  Our variable names can be `$rudolph`, or `$frosty`, or `$mrhankey`.  Our articles
+- Our articles should try and be light and trivial and along the Christmas theme.
+Our variable names can be `$rudolph`, or `$frosty`, or `$mrhankey`.  Our articles
 are often stories of problems fictional Christmas characters have.  In all, we
 try to be entertaining in our articles.
 
 - We like our articles to contain text and code interspersed, and if necessary a final script at the end with lots of comments.
 
-- Pictures, graphs, and other graphics are good and highly encouraged.  In the last few year we included animated gifs of terminal output, renders of spinning OpenGL snowflakes, SVG christmas trees, Christmas cats and dogs from Imgur, Spotify playlists, a full interactive JavaScript map of the world showing off GeoIP location from Perl, and even Perl executing in the browser.  Go nuts!
+- Pictures, graphs, and other graphics are good and highly encouraged.  In the last few years we included animated gifs of terminal output, renders of spinning OpenGL snowflakes, SVG Christmas trees, Christmas cats and dogs from Imgur, Spotify playlists, a full interactive JavaScript map of the world showing off GeoIP location from Perl, and even Perl executing in the browser.  Go nuts!
 
 - Formatting is in POD with a custom header.  See [the source for previous years' articles](https://github.com/perladvent/Perl-Advent/tree/master/2017/articles) for examples.  You can use [`=for html`](https://github.com/perladvent/Perl-Advent/blame/master/2015/articles/2015-12-02.pod#L75) or even [`=for web_only` and `=for rss_only`](https://github.com/perladvent/Perl-Advent/blame/master/2015/articles/2015-12-01.pod#L7) if needed to add custom HTML to your POD.
 


### PR DESCRIPTION
I've updated all of the dates to fit 2022. There are a few fixed typos, and I have removed the Google Plus share button, because G+ is gone.

Two things still need doing:

- There is a link to a Google form. This is out of date. The form exists, but has an old date. We also don't have access to this form.
- Contact details for questions in accepted.md point to Mark's email address. My suggestion would be to replace this with the URL for raising issues in the actual blog repository, so that people who have accepted can raise an issue there and everyone who's involved in running the project can help.

We might just open issues for these.