### PR TITLE
Don't have the rel="canonical" link point at localhost

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Perl Advent Calendar 2023 CFP
 tag_text: Perl Advent Calendar 2023 CFP
 description: The Call For Participation for the 2023 Perl Advent Calendar
-url: "http://127.0.0.1:4000"
+url: "https://cfp.perladvent.org"
 baseurl: ""
 
 font-awesome-include: true # make this false if you don't need font-awesome


### PR DESCRIPTION
Fixes `<link rel="canonical" href="http://127.0.0.1:4000/" />`. Closes #9 